### PR TITLE
update readme layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Module to expose build config variables set in Gradle to your javascript code in React Native.
 
-Inspired from deprecated [luggit/react-native-build-config](https://github.com/luggit/react-native-build-config).
-
 iOS version greatly contributed by [maddijoyce](https://github.com/maddijoyce)
 
 ## Install
@@ -12,51 +10,7 @@ iOS version greatly contributed by [maddijoyce](https://github.com/maddijoyce)
 npm i react-native-build-config
 ```
 
-#### For React Native < 0.60 use version 0.1.0
-
-## Native Modules are now Autolinked
-
-## Manually link
-
-1.  Include this module in `android/settings.gradle`:
-
-```
-include ':react-native-build-config'
-include ':app'
-
-project(':react-native-build-config').projectDir = new File(rootProject.projectDir,
-  '../node_modules/react-native-build-config/android')
-```
-
-2.  Add a dependency to your app build in `android/app/build.gradle`:
-
-```
-dependencies {
-    ...
-    compile project(':react-native-build-config')
-}
-```
-
-3.  Change your main activity to add a new package, in `android/app/src/main/.../MainActivity.java`:
-
-```java
-import com.ismaeld.RNBuildConfig.RNBuildConfigPackage; // add import
-
-public class MainApplication extends Application implements ReactApplication {
-
-  private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
-
-      /* ... */
-
-      @Override
-      protected List<ReactPackage> getPackages() {
-          return Arrays.<ReactPackage>asList(
-                  new MainReactPackage(),
-                  new RNBuildConfigPackage(BuildConfig.class), // add the package here
-          );
-      }
-  };
-```
+:warning: For React Native < 0.60, use version 0.1.0 and use manual linking (see below)		
 
 ## Usage
 
@@ -99,3 +53,47 @@ Gradle sets some variables by default:
 - `APPLICATION_ID`: Your package name, eg: `com.Example`
 - `DEBUG`: set to `true` when running the app locally
 - `BUILD_TYPE` and `FLAVOR`: more build settings
+
+## Linking on React Native < 0.60
+
+Native modules are auto-linked since v0.60. If you have a lower version, you need this:
+
+1.  Include this module in `android/settings.gradle`:
+
+```
+include ':react-native-build-config'
+include ':app'
+
+project(':react-native-build-config').projectDir = new File(rootProject.projectDir,
+  '../node_modules/react-native-build-config/android')
+```
+
+2.  Add a dependency to your app build in `android/app/build.gradle`:
+
+```
+dependencies {
+    ...
+    compile project(':react-native-build-config')
+}
+```
+
+3.  Change your main activity to add a new package, in `android/app/src/main/.../MainActivity.java`:
+
+```java
+import com.ismaeld.RNBuildConfig.RNBuildConfigPackage; // add import
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
+
+      /* ... */
+
+      @Override
+      protected List<ReactPackage> getPackages() {
+          return Arrays.<ReactPackage>asList(
+                  new MainReactPackage(),
+                  new RNBuildConfigPackage(BuildConfig.class), // add the package here
+          );
+      }
+  };
+```


### PR DESCRIPTION
It was confusing to have the manual linking steps described. Move RN < 0.60 to the bottom and add a more explicit warning.

Also, the link to the other project is dead.