### PR TITLE
Build.gradle: always target newest react-native version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,5 +29,5 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:0.13.+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
0.62.0-rc.2 fails for me with the following error:

```
* What went wrong:
Execution failed for task ':react-native-build-config:javaPreCompileDebug'.
> Could not resolve all files for configuration ':react-native-build-config:debugCompileClasspath'.
   > Failed to transform react-native-0.13.0.aar (com.facebook.react:react-native:0.13.0) to match attributes {artifactType=android-classes, org.gradle.category=libra
ry, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}.
      > Execution failed for AarToClassTransform: /home/coco/.gradle/caches/transforms-2/files-2.1/782808d835a5233e0664f2d391bb55b3/jetified-react-native-0.13.0.aar.
         > duplicate entry: META-INF/MANIFEST.MF
```

I am not exactly sure why this is, but making sure that the lib targets the latest react-native version solves the problem. Maybe bumping up the version instead of using + is more appropriate.