### PR TITLE
Add react-native-macos support

### DIFF
--- a/ios/RNBuildConfig.xcodeproj/project.pbxproj
+++ b/ios/RNBuildConfig.xcodeproj/project.pbxproj
@@ -8,10 +8,20 @@
 
 /* Begin PBXBuildFile section */
 		B3E7B58A1CC2AC0600A0062D /* RNBuildConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNBuildConfig.m */; };
+		CCC8A27E27EA874B0009BA6F /* RNBuildConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNBuildConfig.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		58B511D91A9E6C8500147676 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CCC8A28027EA874B0009BA6F /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "include/$(PRODUCT_NAME)";
@@ -26,10 +36,18 @@
 		134814201AA4EA6300B7C361 /* libRNBuildConfig.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNBuildConfig.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3E7B5881CC2AC0600A0062D /* RNBuildConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNBuildConfig.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RNBuildConfig.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNBuildConfig.m; sourceTree = "<group>"; };
+		CCC8A28427EA874B0009BA6F /* libRNBuildConfig-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libRNBuildConfig-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		58B511D81A9E6C8500147676 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CCC8A27F27EA874B0009BA6F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -53,15 +71,16 @@
 				B3E7B5881CC2AC0600A0062D /* RNBuildConfig.h */,
 				B3E7B5891CC2AC0600A0062D /* RNBuildConfig.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
+				CCC8A28427EA874B0009BA6F /* libRNBuildConfig-macOS.a */,
 			);
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		58B511DA1A9E6C8500147676 /* RNBuildConfig */ = {
+		58B511DA1A9E6C8500147676 /* RNBuildConfig-iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "RNBuildConfig" */;
+			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "RNBuildConfig-iOS" */;
 			buildPhases = (
 				58B511D71A9E6C8500147676 /* Sources */,
 				58B511D81A9E6C8500147676 /* Frameworks */,
@@ -71,9 +90,26 @@
 			);
 			dependencies = (
 			);
-			name = RNBuildConfig;
+			name = "RNBuildConfig-iOS";
 			productName = RCTDataManager;
 			productReference = 134814201AA4EA6300B7C361 /* libRNBuildConfig.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		CCC8A27C27EA874B0009BA6F /* RNBuildConfig-macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CCC8A28127EA874B0009BA6F /* Build configuration list for PBXNativeTarget "RNBuildConfig-macOS" */;
+			buildPhases = (
+				CCC8A27D27EA874B0009BA6F /* Sources */,
+				CCC8A27F27EA874B0009BA6F /* Frameworks */,
+				CCC8A28027EA874B0009BA6F /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "RNBuildConfig-macOS";
+			productName = RCTDataManager;
+			productReference = CCC8A28427EA874B0009BA6F /* libRNBuildConfig-macOS.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -95,6 +131,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;
@@ -102,7 +139,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				58B511DA1A9E6C8500147676 /* RNBuildConfig */,
+				58B511DA1A9E6C8500147676 /* RNBuildConfig-iOS */,
+				CCC8A27C27EA874B0009BA6F /* RNBuildConfig-macOS */,
 			);
 		};
 /* End PBXProject section */
@@ -113,6 +151,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				B3E7B58A1CC2AC0600A0062D /* RNBuildConfig.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CCC8A27D27EA874B0009BA6F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CCC8A27E27EA874B0009BA6F /* RNBuildConfig.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -157,6 +203,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -194,6 +241,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -204,7 +252,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				"$(inherited)",
+					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
@@ -232,6 +280,40 @@
 			};
 			name = Release;
 		};
+		CCC8A28227EA874B0009BA6F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		CCC8A28327EA874B0009BA6F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -244,11 +326,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "RNBuildConfig" */ = {
+		58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "RNBuildConfig-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				58B511F01A9E6C8500147676 /* Debug */,
 				58B511F11A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CCC8A28127EA874B0009BA6F /* Build configuration list for PBXNativeTarget "RNBuildConfig-macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CCC8A28227EA874B0009BA6F /* Debug */,
+				CCC8A28327EA874B0009BA6F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/react-native-build-config.podspec
+++ b/react-native-build-config.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc   = true
   s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.9'
 
   s.preserve_paths = 'README.md', 'package.json', 'lib/index.js'
   s.source_files   = 'ios/*.{h,m}'


### PR DESCRIPTION
This pull request adds support for react-native-macos.
No code changes had to be done, the project just had to be configured for macOS too.

Not sure why `react-native-build-config.podspec` was rewritten, can fix if you want.