### PR TITLE
Ios build Fails in Xcode 15 with React Native 0.74.0

### DIFF
--- a/ios/RNBuildConfig.h
+++ b/ios/RNBuildConfig.h
@@ -1,11 +1,3 @@
-
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
-
 @interface RNBuildConfig : NSObject <RCTBridgeModule>
-
 @end
-  


### PR DESCRIPTION
This change resolves build fails issue by implementing the new native module method architecture 

https://reactnative.dev/docs/native-modules-ios#create-custom-native-module-files

Error log
```
❌  /Users/[REDACTED]/git/node_modules/react-native/React/Base/RCTBridgeModule.h:151:56: expected ';' at end of declaration list

@property (nonatomic, weak, readonly) RCTBridge *bridge RCT_DEPRECATED;
          ^

❌  /Users/[REDACTED]/git/node_modules/react-native/React/Base/RCTBridgeModule.h:151:57: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]

@property (nonatomic, weak, readonly) RCTBridge *bridge RCT_DEPRECATED;
                                                       ^
❌  /Users/[REDACTED]/git/node_modules/react-native/React/Base/RCTBridgeModule.h:164:69: expected ';' at end of declaration list

@property (nonatomic, strong, readonly) dispatch_queue_t methodQueue RCT_DEPRECATED;
                                                        ^



❌  /Users/[REDACTED]/git/node_modules/react-native/React/Base/RCTBridgeModule.h:164:70: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]

@property (nonatomic, strong, readonly) dispatch_queue_t methodQueue RCT_DEPRECATED;
                                                                    ^



❌  /Users/[REDACTED]/git/node_modules/react-native/React/Base/RCTBridgeModule.h:151:57: cannot declare variable inside @interface or @protocol

@property (nonatomic, weak, readonly) RCTBridge *bridge RCT_DEPRECATED;
                                                                     ^



❌  /Users/[REDACTED]/git/node_modules/react-native/React/Base/RCTBridgeModule.h:164:70: cannot declare variable inside @interface or @protocol

@property (nonatomic, strong, readonly) dispatch_queue_t methodQueue RCT_DEPRECATED;
                                                        ^



❌  /Users/[REDACTED]/git/node_modules/react-native/React/Base/RCTBridgeModule.h:366:1: duplicate interface definition for class 'RCTModuleRegistry'

@interface RCTModuleRegistry : NSObject
                                                                     ^



❌  /Users/[REDACTED]/git/node_modules/react-native/React/Base/RCTBridgeModule.h:382:1: duplicate interface definition for class 'RCTViewRegistry'

@interface RCTViewRegistry : NSObject
           ^



❌  /Users/[REDACTED]/git/node_modules/react-native/React/Base/RCTBridgeModule.h:400:1: duplicate interface definition for class 'RCTCallableJSModules'

@interface RCTCallableJSModules : NSObject
           ^

```